### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var MyFilter = function(inputTree, options) {
   Filter.apply(this, arguments)
 }
 MyFilter.prototype = Object.create(Filter.prototype)
-MyFilter.processFileContent = function(content, relPath, srcDir) {
+MyFilter.prototype.processFileContent = function(content, relPath, srcDir) {
   return 'content of filtered file'
 
   // You can return an array, when you need to create more than one file,


### PR DESCRIPTION
Documentation stated `MyFilter.processFileContent` instead of `MyFilter.prototype.processFileContent`.
